### PR TITLE
Wrong value order of ONYX_GENERATE_APP_CONFIG option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ option(ONYX_BUILD_TESTS "Build tests" OFF)
 option(ONYX_STATIC_ANALYSIS "Turn static analysis on/off" OFF)
 option(ONYX_GENERATE_DATA_SYMLINK "Turn static analysis on/off" OFF)
 
-cmake_dependent_option(ONYX_GENERATE_APP_CONFIG "Generate default application config" ON "PROJECT_IS_TOP_LEVEL" OFF)
+cmake_dependent_option(ONYX_GENERATE_APP_CONFIG "Generate default application config" OFF "PROJECT_IS_TOP_LEVEL" ON)
 
 # String Options
 set(ONYX_INSTALL_CMAKEDIR ${CMAKE_INSTALL_LIBDIR}/cmake/onyx-${ONYX_VERSION_SUFFIX} CACHE STRING "Path to onyx cmake files")


### PR DESCRIPTION
If Onyx repo is cloned from Onyx-TemplateProject then CMake is not creating application config file. This is happening because of the wrong order of ON/OFF parameters.

From CMake doc:

```
cmake_dependent_option(<variable> <help> <value> <condition> <else-value>)

<condition>
    Specifies the conditions that determine whether <variable> is set and visible in the GUI.

    - If <condition> evaluates to boolean false, option is hidden from the user in the GUI, and a local variable <variable> is set to <else-value>.
```

