### PR TITLE
Clarify PolyForm Noncommercial licensing terms in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Follow the steps to configure, and build the Onyx engine depending on your platf
 Required Notice: Copyright AkElements
 
 Source code in this repository, unless otherwise stated, is licensed under the PolyForm Noncommercial License 1.0.0.
-https://polyformproject.org/licenses/noncommercial/1.0.0/
+https://polyformproject.org/licenses/noncommercial/1.0.0
 
 Any binaries derived from this source code are subject to the same license terms and must
 include this notice. Commercial use, distribution, or sale of such binaries is not permitted

--- a/README.md
+++ b/README.md
@@ -81,7 +81,11 @@ Follow the steps to configure, and build the Onyx engine depending on your platf
 
 Required Notice: Copyright AkElements
 
-This repository is licensed under the PolyForm Noncommercial License 1.0.0
+Source code in this repository, unless otherwise stated, is licensed under the PolyForm Noncommercial License 1.0.0.
 https://polyformproject.org/licenses/noncommercial/1.0.0/
+
+Any binaries derived from this source code are subject to the same license terms and must
+include this notice. Commercial use, distribution, or sale of such binaries is not permitted
+without a separate written agreement with the copyright holder.
 
 For questions regarding the license or if you would like to have a more permissive license feel free to contact me. (akelements.dev@gmail.com)


### PR DESCRIPTION
## Summary

Clarify the PolyForm Noncommercial 1.0.0 licensing terms in the README:
make it explicit that the terms apply to source code in the repo
(unless otherwise stated) and that binaries derived from it are
subject to the same terms, with a note that commercial use of
binaries requires a separate written agreement.

## Changes

- `README.md`: reword the licensing notice to cover source code and
  binaries, and call out the commercial-use restriction.